### PR TITLE
Enrol service_vcl into prc

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -70,7 +70,11 @@ func makeResource(mod string, res string) tokens.Type {
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
-	p := shimv2.NewProvider(fastly.Provider())
+	p := shimv2.NewProvider(
+		fastly.Provider(),
+		shimv2.WithPlanResourceChange(func(tfResourceType string) bool {
+			return tfResourceType == "fastly_service_vcl"
+		}))
 
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{


### PR DESCRIPTION
This enrols the service_vcl resource into PRC. This fixes a panic related to PlanState diff

Needs https://github.com/pulumi/pulumi-terraform-bridge/pull/1971/files to fix https://github.com/pulumi/pulumi-terraform-bridge/issues/1964