### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/cmd/pulumi-resource-fastly/schema.json
+++ b/provider/cmd/pulumi-resource-fastly/schema.json
@@ -1,5 +1,6 @@
 {
     "name": "fastly",
+    "displayName": "Fastly",
     "description": "A Pulumi package for creating and managing fastly cloud resources.",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -78,6 +78,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:                 p,
 		Name:              "fastly",
+		DisplayName:       "Fastly",
 		TFProviderVersion: "4",
 		Description:       "A Pulumi package for creating and managing fastly cloud resources.",
 		Keywords:          []string{"pulumi", "fastly"},


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.